### PR TITLE
Avoid crash on temporary item creation

### DIFF
--- a/scripts/patches/initialize-formula-groups.mjs
+++ b/scripts/patches/initialize-formula-groups.mjs
@@ -12,7 +12,7 @@ export function patchItemPrepareData() {
 
 export function patchItemSheetGetData() {
     libWrapper.register(MODULE_NAME, "game.dnd5e.applications.ItemSheet5e.prototype.getData", async function patchedGetData(wrapped, ...args) {
-        if (this.isEditable) await initializeFormulaGroups(this.document);
+        if (this.isEditable && this.document.id != null) await initializeFormulaGroups(this.document);
         return wrapped(...args);
     }, "WRAPPER");
 }


### PR DESCRIPTION
This fixes the case where a temporary item cannot be rendered under MRE, due to a failed attempt to update it via the database (which will always fail, as the temp item does not exist in the database).

Repro:

```js
(async () => {
	const tempItem = await Item.create(
		{
			name: "Test",
			type: "weapon",
			data: {
				damage: {
					parts: [
						["1d6", "fire"],
					],
				}
			},
		},
		{
			temporary: true,
		},
	);
	tempItem.sheet.render(true);
})();
```

A more robust fix may involve updating the temporary item via some other means, but this change aims only to restores base Foundry functionality.