### PR TITLE
refactor: remove attack button replacement and rely on core card creation logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,3 +43,13 @@ jobs:
         artifacts: './module.json, ./module.zip'
         tag: ${{ github.event.release.tag_name }}
         body: ${{ github.event.release.body }}
+
+    # Publish this new version to the Foundry VTT Module Listing
+    - name: FoundryVTT AutoPublish
+      uses: Varriount/fvtt-autopublish@v1.0.2a
+      with:
+        username: ${{ secrets.FOUNDRY_ADMIN_USER }}
+        password: ${{ secrets.FOUNDRY_ADMIN_PW }}
+        module-id: 833
+        manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+        manifest-file: module.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## [3.0.0] 2021-10-16
+Big Refactor of the patches to reduce complexity. Behavior for users is largely unchanged with one exception:
+
+### Auto Roll Attack
+Item Card no longer replaces the attack button (or use tool button) with the roll outcome for automatic item checks, instead a standard 5e attack roll/ability check card is created. This has several benefits:
+
+- Spells like Spiritual Weapon which warrant several attack rolls after being popped out are easier to use.
+- There is dramatically less complexity in the Item#roll override.
+- Allows modules like Automated Animations to do less work to detect an Attack Roll.
+
+## [2.0.4] 2021-09-03
+I'm not super sure how #2's item got configured that way but at least now we won't choke on it.
+
+## [2.0.2] 2021-08-28
+Avoid crash on temporary item creation. Thanks @TheGiddyLimit
+
 ## [2.0.1] 2021-08-20
 
 Fixes some Flags and Dice

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Minimal Rolling Enhancements (MRE) for D&D5e
 
-> ### Maintenance Mode
-> I have forked this from the original repository to keep it going but am not actively improving it.
-
 Some minimalist enhancements to the core D&D5e rolling workflow.
 MRE is intended to stay as close as possible to core behavior while improving convenience.
 A key philosophy for this module is to remain non-disruptive to minimize conflicts with system and core updates.
@@ -12,7 +9,7 @@ If you are looking for high levels of automation, you should consider using othe
 
 ## Features
 
-Visit the [User Guide](https://github.com/schultzcole/FVTT-Minimal-Rolling-Enhancements-DND5E/wiki/User-Guide) for more information on each feature and informative screenshots.
+Visit the [User Guide](https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E/wiki/User-Guide) for more information on each feature and informative screenshots.
 
 ![A screenshot of a weapon chat card displaying a variety of MRE features](https://f002.backblazeb2.com/file/cws-images/FVTT-MRE/flame-tongue.webp)
 
@@ -23,7 +20,6 @@ Visit the [User Guide](https://github.com/schultzcole/FVTT-Minimal-Rolling-Enhan
   - You can set world-level default modifiers, but players may choose to set a local override if they wish.
 - Settings to **automatically roll attack rolls** and/or **damage rolls** when an item is rolled from the character sheet or a macro.
   - These global settings can be overridden on a per-item basis for full configurability.
-- Attack rolls and tool checks **merged with item cards**.
 - **Formula groups** allow for you to configure sets of damage formulae to be rolled together.
 - Distinct damage formulae within a damage roll are **displayed separately**, for ease of selectively applying resistance/vulnerability.
 
@@ -34,6 +30,10 @@ Not compatible with other modules which modify D&D5e item rolls.
 Minimal Rolling Enhancements is compatible with [libWrapper](https://foundryvtt.com/packages/lib-wrapper/),
 however installing the libWrapper module is *optional*.
 You are not required to install libWrapper for MRE to work correctly, however installing it may reduce conflicts with other modules.
+
+### PopOut!
+
+Using Alt/Shift/Control modifier keys from popped out sheets to bypass item roll dialogs is not supported.
 
 ## License
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "mre-dnd5e",
   "title": "Minimal Rolling Enhancements for D&D5e",
   "description": "Some minimalist enhancements to the core D&D5e rolling workflow. Attempts to stay as close to core as possible while improving convenience.",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "author": "Cole Schultz, Andrew Krigline",
   "authors": [
     {

--- a/module.json
+++ b/module.json
@@ -35,7 +35,7 @@
       "path": "lang/en.json"
     }
   ],
-  "minimumCoreVersion": "0.8.5",
+  "minimumCoreVersion": "0.8.9",
   "compatibleCoreVersion": "0.8.9",
   "url": "https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E",
   "manifest": "https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E/releases/latest/download/module.json",

--- a/scripts/modifiers.mjs
+++ b/scripts/modifiers.mjs
@@ -1,4 +1,5 @@
-export const modifiers = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, clientX: null, clientY: null };
+const blankModifiers = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, clientX: null, clientY: null };
+export let modifiers = { ...blankModifiers };
 
 const updateModifiers = event => {
     modifiers.altKey = event.altKey;
@@ -16,4 +17,8 @@ document.addEventListener("mousedown", event => {
 document.addEventListener("mouseup", () => {
     modifiers.clientX = null;
     modifiers.clientY = null;
+});
+
+window.addEventListener('blur', () => {
+    modifiers = {...blankModifiers};
 });

--- a/scripts/patches/item-base-roll-patch.mjs
+++ b/scripts/patches/item-base-roll-patch.mjs
@@ -3,79 +3,42 @@ import { MODULE_NAME } from "../const.mjs";
 import { SETTING_NAMES } from "../settings.mjs";
 import { modifiers } from "../modifiers.mjs";
 import { initializeFormulaGroups } from "./initialize-formula-groups.mjs";
-import { pause } from "../utils.mjs";
 
+/**
+ * When I roll an Item, also roll the item check/attack and damage if the options say to do so
+ */
 export function patchItemBaseRoll() {
     libWrapper.register(MODULE_NAME, "CONFIG.Item.documentClass.prototype.roll", async function patchedRoll(wrapped, ...args) {
-        await initializeFormulaGroups(this);
-
-        const capturedModifiers = foundry.utils.deepClone(modifiers);
-
         const autoRollCheckSetting = game.settings.get(MODULE_NAME, SETTING_NAMES.AUTO_CHECK);
         const autoRollDamageSetting = game.settings.get(MODULE_NAME, SETTING_NAMES.AUTO_DMG);
         const autoRollCheckWithOverride = this.getFlag(MODULE_NAME, "autoRollAttack") ?? autoRollCheckSetting;
         const autoRollDamageWithOverride = this.getFlag(MODULE_NAME, "autoRollDamage") ?? autoRollDamageSetting;
         const autoRollOther = this.getFlag(MODULE_NAME, "autoRollOther");
 
-        // Force our call to the original Item5e#roll to not show a chat card, but remember whether *our* caller wants a chat message or not
-        // If the caller above us set createMessage to false, we should not create a chat card and instead just return our message data.
-        let originalCreateMessage = true;
-        if (args.length) {
-            originalCreateMessage = args[0].createMessage ?? originalCreateMessage;
-            foundry.utils.mergeObject(args[0], { createMessage: false });
-        } else {
-            args.push({ createMessage: false });
-        }
-
         // Call the original Item5e#roll and get the resulting message data
         const messageData = await wrapped(...args);
 
-        // User quit out of the dialog workflow early (or some other failure)
-        if (!messageData) return;
+        // Short circuit if auto roll is off for this user/item
+        // OR if User quit out of the dialog workflow early (or some other failure)
+        if ((!autoRollCheckWithOverride && !autoRollDamageWithOverride && !autoRollOther) || !messageData) {
+            return messageData;
+        }
 
-        // Make a roll if auto rolls is on, and replace the appropriate button in the item card with the rendered roll results
+        await initializeFormulaGroups(this);
+        const capturedModifiers = foundry.utils.deepClone(modifiers);
+
+        // Make a roll if auto rolls is on
         let checkRoll;
-        let expectRoll;
         if (autoRollCheckWithOverride) {
-            let title;
             if (this.hasAttack) {
-                expectRoll = true;
-                checkRoll = await this.rollAttack({ event: capturedModifiers, chatMessage: false });
-                if (checkRoll) {
-                    title = _createWeaponTitle(this, checkRoll);
-                    messageData.flags["dnd5e.roll.type"] = "attack";
-                }
+                checkRoll = await this.rollAttack({ event: capturedModifiers });
             } else if (this.type === "tool") {
-                expectRoll = true;
-                checkRoll = await this.rollToolCheck({ event: capturedModifiers, chatMessage: false  });
-                if (checkRoll) {
-                    title = _createToolTitle(this, checkRoll);
-                    messageData.flags["dnd5e.roll.type"] = "tool";
-                }
-            }
-
-            if (checkRoll) {
-                await _replaceAbilityCheckButtonWithRollResult(messageData, this, checkRoll, title);
-
-                messageData.flags["dnd5e.roll.itemId"] = this.id;
-                messageData.flavor = undefined;
-                messageData.roll = checkRoll;
-                messageData.type = foundry.CONST.CHAT_MESSAGE_TYPES.ROLL;
-                messageData.sound = CONFIG.sounds.dice;
-            } else if (expectRoll) {
-                return;
+                checkRoll = await this.rollToolCheck({ event: capturedModifiers });
             }
         }
 
-        if (this.hasDamage) _replaceDamageButtons(messageData, this);
-
-        const result = originalCreateMessage ? await _createMessage(messageData) : messageData;
-
         if (this.hasDamage && autoRollDamageWithOverride) {
-            await pause(100);
-
-            // Extract spell level from the message data created by the wrapped call to Item#roll
-            const spellLevel = parseInt($(messageData.content).attr("data-spell-level"));
+            const spellLevel = this.data.data.level;
 
             const options = { event: capturedModifiers, spellLevel };
             if (args.length && Number.isNumeric(args[0].spellLevel)) options.spellLevel = args[0].spellLevel;
@@ -86,101 +49,7 @@ export function patchItemBaseRoll() {
         }
 
         if (this.data.data.formula?.length && autoRollOther) {
-            await pause(100);
             await this.rollFormula({ event: capturedModifiers });
         }
-
-        return result;
     }, "WRAPPER");
-}
-
-function _createWeaponTitle(item, roll) {
-    let title = game.i18n.localize("DND5E.AttackRoll");
-
-    const itemData = item.data.data;
-    const consume = itemData.consume;
-    if (consume?.type === "ammo") {
-        const ammo = item.actor.items.get(consume.target);
-        if (ammo) {
-            title += ` [${ammo.name}]`;
-        }
-    }
-
-    if (roll.terms[0].options.advantage) {
-        title += ` (${game.i18n.localize("DND5E.Advantage")})`;
-    } else if (roll.terms[0].options.disadvantage) {
-        title += ` (${game.i18n.localize("DND5E.Disadvantage")})`;
-    }
-
-    return title;
-}
-
-function _createToolTitle(item, roll) {
-    let title = game.i18n.localize("DND5E.ToolCheck");
-
-    if (roll.terms[0].options.advantage) {
-        title += ` (${game.i18n.localize("DND5E.Advantage")})`;
-    } else if (roll.terms[0].options.disadvantage) {
-        title += ` (${game.i18n.localize("DND5E.Disadvantage")})`;
-    }
-
-    return title;
-}
-
-async function _replaceAbilityCheckButtonWithRollResult(messageData, item, roll, title) {
-    const content = $(messageData.content);
-    content.find(".chat-card").addClass("mre-item-card");
-    const cardContent = content.find(".card-content");
-
-    // Remove existing attack and tool check buttons
-    content.find("[data-action=attack],[data-action=toolCheck]").remove();
-
-    // Add separator between item description and roll
-    cardContent.append("<hr />");
-
-    // Add the attack roll to the card
-    const cardRoll = $(`<div class="card-roll">`);
-    cardRoll.append(`<span class="flavor-text">${title}</span>`);
-    cardRoll.append(await roll.render());
-    cardContent.after(cardRoll);
-
-    // Add separator between roll and roll buttons
-    const cardButtons = content.find(".card-buttons");
-    if (cardButtons.find("button").length > 0) cardButtons.before("<hr />");
-
-    messageData.content = content.prop("outerHTML");
-}
-
-function _replaceDamageButtons(messageData, item) {
-    const content = $(messageData.content);
-    content.find(".chat-card").addClass("mre-item-card");
-
-    // Remove existing damage and versatile buttons
-    content.find("[data-action=damage],[data-action=versatile]").remove();
-
-    // Create formula group buttons
-    const formulaGroups = item.getFlag(MODULE_NAME, "formulaGroups");
-    const damageText = game.i18n.localize("DND5E.Damage");
-    const healingText = game.i18n.localize("DND5E.Healing");
-    const damageButtons = formulaGroups.map((group, i) => {
-        let buttonText = item.data.data.actionType === "heal" ? healingText : damageText;
-        if (formulaGroups.length > 1) buttonText += ` (${group.label})`;
-        return $(`<button data-action="formula-group" data-formula-group="${i}">${buttonText}</button>`);
-    });
-
-    // Inject formula group buttons
-    const attackButton = content.find("[data-action=attack],[data-action=toolCheck]").last();
-    const cardButtons = content.find(".card-buttons");
-    if (attackButton.length) {
-        attackButton.after(damageButtons);
-    } else {
-        cardButtons.prepend(damageButtons);
-    }
-
-    messageData.content = content.prop("outerHTML");
-}
-
-function _createMessage(messageData) {
-    const msg = new ChatMessage(messageData);
-    return ChatMessage.create(msg.data);
 }

--- a/scripts/patches/item-display-card-patch.mjs
+++ b/scripts/patches/item-display-card-patch.mjs
@@ -1,0 +1,61 @@
+import { libWrapper } from "../../lib/libWrapper/shim.js";
+import { MODULE_NAME } from "../const.mjs";
+import { initializeFormulaGroups } from "./initialize-formula-groups.mjs";
+
+// When I create an Item chat card, replace the damage buttons with our custom ones.
+export function patchItemDisplayCard() {
+    libWrapper.register(MODULE_NAME, "CONFIG.Item.documentClass.prototype.displayCard", async function patchedDisplayCard(wrapped, options, ...rest) {
+        await initializeFormulaGroups(this);
+
+        // If the caller above us set createMessage to false, we should not create a chat card and instead just return our message data.
+        const shouldCreateMessage = options?.createMessage ?? true;
+
+        // we create the message ourselves, don't want the original method to create
+        const wrappedOptions = {...options, createMessage: false };
+
+        // Call the original Item5e#roll and get the resulting message data
+        const messageData = await wrapped(wrappedOptions, ...rest);
+
+        // User quit out of the dialog workflow early (or some other failure)
+        if (!messageData) return;
+
+        if (this.hasDamage) _replaceDamageButtons(messageData, this);
+
+        const result = shouldCreateMessage ? await ChatMessage.create(messageData) : messageData;
+
+        return result;
+    }, "WRAPPER");
+}
+
+/**
+ * Replace stock damage buttons with our buttons for each damage group
+ * Mutates input messageData
+ */
+function _replaceDamageButtons(messageData, item) {
+    const content = $(messageData.content);
+    content.find(".chat-card").addClass("mre-item-card");
+
+    // Remove existing damage and versatile buttons
+    content.find("[data-action=damage],[data-action=versatile]").remove();
+
+    // Create formula group buttons
+    const formulaGroups = item.getFlag(MODULE_NAME, "formulaGroups");
+    const damageText = game.i18n.localize("DND5E.Damage");
+    const healingText = game.i18n.localize("DND5E.Healing");
+    const damageButtons = formulaGroups.map((group, i) => {
+        let buttonText = item.data.data.actionType === "heal" ? healingText : damageText;
+        if (formulaGroups.length > 1) buttonText += ` (${group.label})`;
+        return $(`<button data-action="formula-group" data-formula-group="${i}">${buttonText}</button>`);
+    });
+
+    // Inject formula group buttons
+    const attackButton = content.find("[data-action=attack],[data-action=toolCheck]").last();
+    const cardButtons = content.find(".card-buttons");
+    if (attackButton.length) {
+        attackButton.after(damageButtons);
+    } else {
+        cardButtons.prepend(damageButtons);
+    }
+
+    messageData.content = content.prop("outerHTML");
+}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,5 +1,3 @@
-export const pause = (millis) => new Promise(resolve => setTimeout(resolve, millis));
-
 /**
  * Combines multiple Roll objects into a single merged Roll.
  * @param {Roll} rolls

--- a/setup.js
+++ b/setup.js
@@ -3,6 +3,7 @@ import { patchAbilityChecks } from "./scripts/patches/ability-check-patches.mjs"
 import { patchItemBaseRoll } from "./scripts/patches/item-base-roll-patch.mjs";
 import { patchItemRollDamage } from "./scripts/patches/item-damage-patch.mjs";
 import { patchItemPrepareData, patchItemSheetGetData } from "./scripts/patches/initialize-formula-groups.mjs";
+import { patchItemDisplayCard } from "./scripts/patches/item-display-card-patch.mjs";
 import { patchTokenFromActor } from "./scripts/patches/token-from-actor-patch.mjs";
 import { registerSettings } from "./scripts/settings.mjs";
 
@@ -10,7 +11,8 @@ Hooks.on("setup", () => {
     console.log(`${MODULE_TITLE_SHORT} | Initializing ${MODULE_TITLE}`);
     registerSettings();
     patchAbilityChecks();
-    patchItemBaseRoll()
+    patchItemBaseRoll();
+    patchItemDisplayCard();
     patchItemRollDamage();
     patchItemPrepareData();
     patchItemSheetGetData();


### PR DESCRIPTION
Version 3!

- Guts a lot of complexity in favor of default behaviors for attack/tool checks.
