### PR TITLE
fix: always return chat message from item base roll

### DIFF
--- a/scripts/patches/item-base-roll-patch.mjs
+++ b/scripts/patches/item-base-roll-patch.mjs
@@ -55,5 +55,7 @@ export function patchItemBaseRoll() {
         if (this.data.data.formula?.length && autoRollOther) {
             await this.rollFormula();
         }
+
+        return chatMessage;
     }, "WRAPPER");
 }


### PR DESCRIPTION
Fixes a dumb mistake wherein we accidentally changed the return signature of item.roll.