### PR TITLE
feat: add support for items-with-rolltables-5e

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Minimal Rolling Enhancements is compatible with [libWrapper](https://foundryvtt.
 however installing the libWrapper module is *optional*.
 You are not required to install libWrapper for MRE to work correctly, however installing it may reduce conflicts with other modules.
 
+### [Items with Rollable Tables](https://github.com/ElfFriend-DnD/foundryvtt-items-with-rolltables-5e)
+
+Fully supported, including options to automatically roll the rollable table when the item is rolled.
+
 ### PopOut!
 
 Using Alt/Shift/Control modifier keys from popped out sheets to bypass item roll dialogs is not supported.

--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,8 @@
       "AutoRollChecksHint": "Automatically roll the attack roll or tool check for the item if it exists.",
       "AutoRollDamageLabel": "Automatically Roll Item Damage",
       "AutoRollDamageHint": "Automatically roll the first formula group for the item if it exists.",
+      "AutoRollRolltableLabel": "Automatically Roll Item Rollable Table",
+      "AutoRollRolltableHint": "Automatically roll the Rollable Table for the item if it exists.",
       "ShowDamageTotalLabel": "Show Total Damage",
       "ShowDamageTotalHint": "Whether or not to show the total result of all individual rolls in a combined damage card.",
       "GlobalDefault": "World Default",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "mre-dnd5e",
   "title": "Minimal Rolling Enhancements for D&D5e",
   "description": "Some minimalist enhancements to the core D&D5e rolling workflow. Attempts to stay as close to core as possible while improving convenience.",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Cole Schultz, Andrew Krigline",
   "authors": [
     {

--- a/scripts/hooks/render-item-5e-sheet.mjs
+++ b/scripts/hooks/render-item-5e-sheet.mjs
@@ -28,9 +28,15 @@ Hooks.on("renderItemSheet5e", (itemSheet, html, _) => {
     otherFormula.after(_makeAutoRollCheckboxElement(itemSheet.document, "Other", false));
 
     // Handle "checkbox" button clicks
-    html.find(`.tab.details button.checkbox:not(.three-way)`).click((event) => _handleTwoWayCheckboxButtonPress(event, itemSheet.document));
-    html.find(`.tab.details button.checkbox.three-way`).click((event) => _handleThreeWayCheckboxButtonPress(event, itemSheet.document));
+    html.on('click', `.tab.details button.checkbox:not(.three-way)`, (event) => _handleTwoWayCheckboxButtonPress(event, itemSheet.document));
+    html.on('click', `.tab.details button.checkbox.three-way`, (event) => _handleThreeWayCheckboxButtonPress(event, itemSheet.document));
 });
+
+// only present if the Items With Rollable Tables module is present
+Hooks.on('items-with-rolltables-5e.sheetMutated', (itemSheet, html) => {
+    const rollableTable = html.find(`.tab.details`).find('.rollable-table-drop-target');
+    rollableTable.append(_makeAutoRollCheckboxElement(itemSheet.document, "Rolltable", true));
+})
 
 function _makeAutoRollCheckboxElement(item, target, threeWay) {
     const text = game.i18n.localize(`${MODULE_NAME}.AUTO-ROLL.AutoRoll`);

--- a/scripts/patches/item-base-roll-patch.mjs
+++ b/scripts/patches/item-base-roll-patch.mjs
@@ -13,9 +13,11 @@ export function patchItemBaseRoll() {
 
         const autoRollCheckSetting = game.settings.get(MODULE_NAME, SETTING_NAMES.AUTO_CHECK);
         const autoRollDamageSetting = game.settings.get(MODULE_NAME, SETTING_NAMES.AUTO_DMG);
+        const autoRollRolltableSetting = game.settings.get(MODULE_NAME, SETTING_NAMES.AUTO_ROLLTABLE);
         const autoRollCheckWithOverride = this.getFlag(MODULE_NAME, "autoRollAttack") ?? autoRollCheckSetting;
         const autoRollDamageWithOverride = this.getFlag(MODULE_NAME, "autoRollDamage") ?? autoRollDamageSetting;
         const autoRollOther = this.getFlag(MODULE_NAME, "autoRollOther");
+        const autoRollRolltableWithOverride = this.getFlag(MODULE_NAME, "autoRollRolltable") ?? autoRollRolltableSetting;
 
         // some rolls only create their chat card after other dialogs have been interacted with
         // we need to capture the active keyboard modifiers on intial use to pass in to later rolls.
@@ -26,7 +28,7 @@ export function patchItemBaseRoll() {
 
         // Short circuit if auto roll is off for this user/item
         // OR if User quit out of the dialog workflow early (or some other failure)
-        if ((!autoRollCheckWithOverride && !autoRollDamageWithOverride && !autoRollOther) || !chatMessage) {
+        if ((!autoRollCheckWithOverride && !autoRollDamageWithOverride && !autoRollOther && !autoRollRolltableWithOverride) || !chatMessage) {
             return chatMessage;
         }
 
@@ -54,6 +56,13 @@ export function patchItemBaseRoll() {
 
         if (this.data.data.formula?.length && autoRollOther) {
             await this.rollFormula();
+        }
+
+        const tableUuid = this.data.flags?.['items-with-rolltables-5e']?.['rollable-table-uuid'];
+
+        if (game.modules.get('items-with-rolltables-5e')?.active && !!tableUuid && autoRollRolltableWithOverride) {
+            const document = await fromUuid(tableUuid);
+            if (!!document) document.draw();
         }
 
         return chatMessage;

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -3,6 +3,7 @@ import { MODULE_NAME } from "./const.mjs";
 export const SETTING_NAMES = {
     AUTO_CHECK: "autoCheck",
     AUTO_DMG: "autoDamage",
+    AUTO_ROLLTABLE: "autoRolltable",
     SHOW_TOTAL_DMG: "showTotalDamage",
     ROLL_DLG_BHVR: "rollDialogBehavior",
     SHOW_ROLL_DLG_MOD: "showRollDialogModifier",
@@ -39,6 +40,16 @@ function _registerAutoRollsSettings() {
         hint: game.i18n.localize(`${MODULE_NAME}.SETTINGS.AutoRollDamageHint`),
         scope: "world",
         config: true,
+        type: Boolean,
+        default: false,
+    });
+
+    // This should only appear if the module is present (until this can be added to the system)
+    game.settings.register(MODULE_NAME, SETTING_NAMES.AUTO_ROLLTABLE, {
+        name: game.i18n.localize(`${MODULE_NAME}.SETTINGS.AutoRollRolltableLabel`),
+        hint: game.i18n.localize(`${MODULE_NAME}.SETTINGS.AutoRollRolltableHint`),
+        scope: "world",
+        config: game.modules.get('items-with-rolltables-5e')?.active,
         type: Boolean,
         default: false,
     });


### PR DESCRIPTION
A new module has appeared which allows Items to have a Rollable Table linked to them. It would be neat to be able to automatically draw from said table when the item is rolled. This should behave exactly the same as Damage does, allowing a global setting as well as individual item overrides.

- Adds a global setting: `Automatically Roll Item Rollable Table`
- Adds a field on the Item Sheet itself to optionally override this behavior.
- When an item is rolled and one of these settings are set to roll, the table's result is automatically drawn on item usage.

![image](https://user-images.githubusercontent.com/7644614/140628570-4b8c862e-04e2-417c-880b-feb215a583f8.png)
