### PR TITLE
Merge dialog options with defaults

### DIFF
--- a/scripts/patches/item-damage-patch.mjs
+++ b/scripts/patches/item-damage-patch.mjs
@@ -34,10 +34,13 @@ export function patchItemRollDamage() {
             : !event[showDamageDialogModifier]);
         // Show a custom dialog that applies to all damage parts
         if (shouldShowDialog) {
-            const dialogOptions = {
-                top: event?.clientY ? event.clientY - 80 : null,
-                left: event?.clientX ? window.innerWidth - 710 : null,
-            };
+            const dialogOptions = mergeObject(
+                options.dialogOptions || {},
+                {
+                    top: event?.clientY ? event.clientY - 80 : null,
+                    left: event?.clientX ? window.innerWidth - 710 : null,
+                }
+            );
             const dialogData = await _damageDialog({ title, rollMode, dialogOptions });
 
             if (!dialogData) return null;


### PR DESCRIPTION
Hello,

This PR to fix a small MRE behavior.

Contrary to the 5e system. When handling damage rolls, MRE do not pass along the dialog options object found in the arguments.
Instead, it ignores the possibly already created dialog `options` object and creates its own.

5e passes the dialog `options` object to the dialog creation method here: https://gitlab.com/foundrynet/dnd5e/-/blob/master/module/dice.js#L352

This PR ensures that the dialog options passed in the `options` object are merged with the MRE own dialog options.

It allows other modules to configure other options in that `options` object (like, ID, classes, etc.).
