### PR TITLE
fix: correctly set parent for items with stored data

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "mre-dnd5e",
   "title": "Minimal Rolling Enhancements for D&D5e",
   "description": "Some minimalist enhancements to the core D&D5e rolling workflow. Attempts to stay as close to core as possible while improving convenience.",
-  "version": "3.2.0",
+  "version": "3.2.6",
   "author": "Cole Schultz, Andrew Krigline",
   "authors": [
     {
@@ -41,7 +41,7 @@
     }
   ],
   "minimumCoreVersion": "0.8.9",
-  "compatibleCoreVersion": "9.232",
+  "compatibleCoreVersion": "9",
   "url": "https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E",
   "manifest": "https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E/releases/latest/download/module.json",
   "download": "https://github.com/ElfFriend-DnD/FVTT-Minimal-Rolling-Enhancements-DND5E/releases/latest/download/module.zip",

--- a/scripts/hooks/render-chat-log.mjs
+++ b/scripts/hooks/render-chat-log.mjs
@@ -1,3 +1,5 @@
+import { MODULE_NAME } from "../const.mjs";
+
 Hooks.on("renderChatLog", (app, html, data) => _handleRenderChatLog(html));
 Hooks.on("renderChatPopout", (app, html, data) => _handleRenderChatLog(html));
 
@@ -18,12 +20,13 @@ function _handleRenderChatLog(html) {
 
         // Get the Item from stored flag data or by the item ID on the Actor
         const storedData = message.getFlag("dnd5e", "itemData");
-        const item = storedData ? new CONFIG.Item.documentClass(storedData, actor) : actor.items.get(card.dataset.itemId);
+        const item = storedData ? new CONFIG.Item.documentClass(storedData, {parent: actor}) : actor.items.get(card.dataset.itemId);
         if ( !item ) {
             return ui.notifications.error(game.i18n.format("DND5E.ActionWarningNoItem", {item: card.dataset.itemId, name: actor.name}))
         }
 
-        const spellLevel = parseInt(card.dataset.spellLevel) || null;
+        const spellLevel = message.getFlag(MODULE_NAME, 'spellLevel') ?? parseInt(card.dataset.spellLevel) ?? null;
+
         const formulaGroup = button.dataset.formulaGroup;
         item.rollDamage({ event, spellLevel, formulaGroup });
     });


### PR DESCRIPTION
We were incorrectly assigning the `parent` actor for cases where the item being rolled was being reconstructed from stored item data.