### PR TITLE
fix: erroneously showing the damage dialog

### DIFF
--- a/scripts/patches/item-damage-patch.mjs
+++ b/scripts/patches/item-damage-patch.mjs
@@ -24,7 +24,7 @@ export function patchItemRollDamage() {
             event = {},
             critical = event[advModifier],
             fastForward = rollDialogBehaviorSetting === "skip"
-                ? !event[showDamageDialogModifier] && !event[advModifier]
+                ? !event[showDamageDialogModifier]
                 : event[showDamageDialogModifier] || event[advModifier],
             options = {}
         } = config;


### PR DESCRIPTION
Resolves #26 that came about because of #22. The first case described in 22 is the reproduction for this. All other cases still function correctly.