### PR TITLE
Fix context menu registration race

### DIFF
--- a/scripts/hooks/damage-card-context-menu.mjs
+++ b/scripts/hooks/damage-card-context-menu.mjs
@@ -23,7 +23,7 @@ ContextMenu.prototype.bind = function patchedBind() {
 /**
  * Register a new context menu to be applied to individual damage rolls in a combined damage card
  */
-Hooks.once("ready", async () => {
+Hooks.once("renderChatLog", async () => {
     let canApply = li => {
         const message = game.messages.get(li.closest(".chat-message").data("messageId"));
         return message.isContentVisible && canvas.tokens.controlled.length;


### PR DESCRIPTION
Sometimes the damage roll context menu is not registered after the default chat message context menu. This fixes that by changing the registration from the ready hook to the on renderChatLog hook, which is guaranteed to be after the default is registered.

Fixes #38 