### PR TITLE
refactor: only use innerRollDamage for the first part of a group

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,11 @@ jobs:
         body: ${{ github.event.release.body }}
 
     # Publish this new version to the Foundry VTT Module Listing
-    - name: FoundryVTT AutoPublish
-      uses: Varriount/fvtt-autopublish@v1.0.2a
-      with:
-        username: ${{ secrets.FOUNDRY_ADMIN_USER }}
-        password: ${{ secrets.FOUNDRY_ADMIN_PW }}
-        module-id: 833
-        manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
-        manifest-file: module.json
+    # - name: FoundryVTT AutoPublish
+    #   uses: Varriount/fvtt-autopublish@v1.0.2a
+    #   with:
+    #     username: ${{ secrets.FOUNDRY_ADMIN_USER }}
+    #     password: ${{ secrets.FOUNDRY_ADMIN_PW }}
+    #     module-id: 833
+    #     manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+    #     manifest-file: module.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,11 @@ jobs:
         body: ${{ github.event.release.body }}
 
     # Publish this new version to the Foundry VTT Module Listing
-    # - name: FoundryVTT AutoPublish
-    #   uses: Varriount/fvtt-autopublish@v1.0.2a
-    #   with:
-    #     username: ${{ secrets.FOUNDRY_ADMIN_USER }}
-    #     password: ${{ secrets.FOUNDRY_ADMIN_PW }}
-    #     module-id: 833
-    #     manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
-    #     manifest-file: module.json
+    - name: FoundryVTT AutoPublish
+      uses: Varriount/fvtt-autopublish@v1.0.2a
+      with:
+        username: ${{ secrets.FOUNDRY_ADMIN_USER }}
+        password: ${{ secrets.FOUNDRY_ADMIN_PW }}
+        module-id: 833
+        manifest-url: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
+        manifest-file: module.json

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "mre-dnd5e",
   "title": "Minimal Rolling Enhancements for D&D5e",
   "description": "Some minimalist enhancements to the core D&D5e rolling workflow. Attempts to stay as close to core as possible while improving convenience.",
-  "version": "3.2.6",
+  "version": "4.0.0",
   "author": "Cole Schultz, Andrew Krigline",
   "authors": [
     {


### PR DESCRIPTION
Resolves #36 as best as can be done within the scope of this module.

Instead of using the wrapped `rollDamage` method for all individual parts, only do so for the first part of a damage group. For all other parts, call `damageRoll` directly.

This allows effect damage boosts, crit bonus damage, etc. to only be applied once in the rolled damage, instead of multiple times accidentally.