### PR TITLE
Use native checkbox input for auto roll checkboxes. (#43)

### DIFF
--- a/mre-styles.css
+++ b/mre-styles.css
@@ -121,34 +121,49 @@
 .sw5e.sheet.item .mre-damage-header-container,
 .tidy5e.sheet.item .mre-damage-header-container {
     display: flex;
+    gap: 6px;
+    align-items: center;
 }
-
 
 .dnd5e.sheet.item .mre-damage-header-container .damage-header,
 .sw5e.sheet.item .mre-damage-header-container .damage-header,
 .tidy5e.sheet.item .mre-damage-header-container .damage-header {
     flex: 1;
-    display: inline-block;
 }
 
-.dnd5e.sheet.item .mre-auto-roll,
-.sw5e.sheet.item .mre-auto-roll,
-.tidy5e.sheet.item .mre-auto-roll {
+.dnd5e.sheet.item label.mre-auto-roll,
+.sw5e.sheet.item label.mre-auto-roll,
+.tidy5e.sheet.item label.mre-auto-roll {
     display: flex;
     flex: 0 0 60px;
     max-height: 24px;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
 }
 
-.tidy5e.sheet.item .mre-damage-header-container .mre-auto-roll {
-    margin: 3px;
+.dnd5e.sheet.item .mre-auto-roll input[type=checkbox],
+.sw5e.sheet.item .mre-auto-roll input[type=checkbox],
+.tidy5e.sheet.item .mre-auto-roll input[type=checkbox] {
+    margin: 0 2px;
+    cursor: pointer;
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.sheet.item .locked label.mre-auto-roll {
+    cursor: default;
+}
+.sheet.item .locked label.mre-auto-roll input[type=checkbox] {
+    cursor: default;
 }
 
 .dnd5e.sheet.item .mre-auto-roll span.label,
 .sw5e.sheet.item .mre-auto-roll span.label,
 .tidy5e.sheet.item .mre-auto-roll span.label {
     display: inline-block;
-    position: relative;
-    width: 0;
     margin: 2px;
     line-height: .9;
     text-transform: uppercase;
@@ -156,82 +171,35 @@
     font-weight: bold;
     letter-spacing: .05rem;
     color: #7a7971;
-}
-
-.dnd5e.sheet.item .mre-auto-roll button.checkbox,
-.sw5e.sheet.item .mre-auto-roll button.checkbox,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox {
-    flex: 1;
-    position: relative;
-    max-width: 16px;
-    height: 16px;
-    top: -2px;
-    border: none;
-    background: none;
-    padding: 0;
-    margin: 5px;
-    cursor: pointer;
+    white-space: normal;
+    text-align: start;
 }
 
 .tidy5e.sheet.item .config-formula-groups {
     color: #7a7971;
     font-size: 16px;
-    margin-right: 4px;
 }
 
-.dnd5e.sheet.item .mre-auto-roll button.checkbox:hover,
-.sw5e.sheet.item .mre-auto-roll button.checkbox:hover,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox:hover {
-    box-shadow: none;
-    text-shadow: 0 0 8px red;
+
+/* Tidy5e Sheet Compatibility */
+.tidy5e.sheet.item .mre-damage-header-container .damage-header {
+    margin: 0;
 }
 
-.dnd5e.sheet.item .mre-auto-roll button.checkbox:before,
-.sw5e.sheet.item .mre-auto-roll button.checkbox:before,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox:before {
-    font-family: "Font Awesome 5 Free";
-    display: inline-block;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-font-smoothing: antialiased;
-    font-weight: 900;
-    font-style: normal;
-    font-variant: normal;
-    text-rendering: auto;
-    line-height: 1;
-    position: absolute;
-    left: 0;
-    top: 1px;
-    color: #7a7971;
+.tidy5e.sheet.item .mre-damage-header-container .damage-header a.add-damage {
+    margin: 0;
 }
 
-.dnd5e.sheet.item .mre-auto-roll button.checkbox.unchecked:before,
-.sw5e.sheet.item .mre-auto-roll button.checkbox.unchecked:before,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox.unchecked:before {
-    content: "\f057"; /* times */
+.tidy5e.sheet.item .sheet-body label.mre-auto-roll input[type=checkbox] {
+    -webkit-appearance: checkbox;
+    -moz-appearance: checkbox;
+    appearance: auto;
 }
 
-.dnd5e.sheet.item .mre-auto-roll button.checkbox.indeterminate:before,
-.sw5e.sheet.item .mre-auto-roll button.checkbox.indeterminate:before,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox.indeterminate:before {
-    content: "\f111"; /* minus */
-    font-weight: 400;
-}
-
-.dnd5e.sheet.item .mre-auto-roll button.checkbox.checked:before,
-.sw5e.sheet.item .mre-auto-roll button.checkbox.checked:before,
-.tidy5e.sheet.item .mre-auto-roll button.checkbox.checked:before {
-    content: "\f058"; /* check */
-}
-
-/* Tidy5e Sheet compatibility for auto roll "checkboxes" */
-.tidy5e.sheet.item .mre-damage-header-container .damage-control {
-    display: inline-block;
-}
-
-.tidy5e.sheet.item .sheet-body .tab.details .form-group .mre-auto-roll button.checkbox {
-    background: none;
-    width: 16px;
-    height: 16px;
-    font-size: 14px;
+/* --primary-accent is defined by tidy5e. it will exist if we get into this block */
+/*noinspection CssUnresolvedCustomProperty*/
+.tidy5e.sheet.item .sheet-body label.mre-auto-roll input[type=checkbox]:hover {
+    -webkit-box-shadow: 0 0 0 1px var(--primary-accent) inset;
+    box-shadow: 0 0 0 1px var(--primary-accent) inset;
 }
 

--- a/scripts/hooks/render-item-5e-sheet.mjs
+++ b/scripts/hooks/render-item-5e-sheet.mjs
@@ -2,9 +2,14 @@ import { MODULE_NAME } from "../const.mjs";
 import { FormulaGroupConfig } from "../apps/formula-group-config.mjs";
 
 Hooks.on("renderItemSheet5e", (itemSheet, html, _) => {
+    const locked = !itemSheet.isEditable;
+
     // Add formula group config button
     const tooltip = game.i18n.localize(`${MODULE_NAME}.FORMULA-GROUP.DialogTitle`);
-    html.find(".tab.details .damage-header").prepend(`<a title="${tooltip}" class="config-formula-groups"><i class="fas fa-tasks"></i></a>`);
+    const damageHeader = html.find(".tab.details .damage-header");
+    damageHeader.wrap(`<div class="mre-damage-header-container">`);
+    damageHeader.before(`<a title="${tooltip}" class="config-formula-groups"><i class="fas fa-tasks"></i></a>`);
+    damageHeader.after(_makeAutoRollCheckboxElement(itemSheet.document, "Damage", true, locked));
 
     // Open the formula group config when the user clicks on the button
     html.find(".config-formula-groups").click(() => new FormulaGroupConfig(itemSheet.document, { editable: itemSheet.isEditable }).render(true) );
@@ -17,88 +22,98 @@ Hooks.on("renderItemSheet5e", (itemSheet, html, _) => {
         // Only show the auto-roll checkbox button if actionType is populated
         const actionType = html.find(`.tab.details`).find(`[name="data.actionType"]`);
         actionType.wrap(`<div class="form-fields">`);
-        actionType.after(_makeAutoRollCheckboxElement(itemSheet.document, "Attack", true));
+        actionType.after(_makeAutoRollCheckboxElement(itemSheet.document, "Attack", true, locked));
     }
 
-    const damageHeader = html.find(".tab.details .damage-header");
-    damageHeader.wrap(`<div class="mre-damage-header-container">`);
-    damageHeader.after(_makeAutoRollCheckboxElement(itemSheet.document, "Damage", true));
-
     const otherFormula = html.find(`.tab.details`).find(`[name="data.formula"]`);
-    otherFormula.after(_makeAutoRollCheckboxElement(itemSheet.document, "Other", false));
+    otherFormula.after(_makeAutoRollCheckboxElement(itemSheet.document, "Other", false, locked));
 
-    // Handle "checkbox" button clicks
-    html.on('click', `.tab.details button.checkbox:not(.three-way)`, (event) => _handleTwoWayCheckboxButtonPress(event, itemSheet.document));
-    html.on('click', `.tab.details button.checkbox.three-way`, (event) => _handleThreeWayCheckboxButtonPress(event, itemSheet.document));
+    if (!locked) {
+        // Handle "checkbox" button clicks
+        html.on('click', `.tab.details input[type=checkbox]:not(.three-way)`, (event) => _handleTwoWayCheckboxButtonPress(event, itemSheet.document));
+        html.on('click', `.tab.details input[type=checkbox].three-way`, (event) => _handleThreeWayCheckboxButtonPress(event, itemSheet.document));
+    }
 });
 
 // only present if the Items With Rollable Tables module is present
 Hooks.on('items-with-rolltables-5e.sheetMutated', (itemSheet, html) => {
+    const locked = !itemSheet.isEditable;
     const rollableTable = html.find(`.tab.details`).find('.rollable-table-drop-target');
-    rollableTable.append(_makeAutoRollCheckboxElement(itemSheet.document, "Rolltable", true));
+    rollableTable.append(_makeAutoRollCheckboxElement(itemSheet.document, "Rolltable", true, locked));
 })
 
-function _makeAutoRollCheckboxElement(item, target, threeWay) {
+function _makeAutoRollCheckboxElement(item, target, threeWay, locked) {
     const text = game.i18n.localize(`${MODULE_NAME}.AUTO-ROLL.AutoRoll`);
-    const element = $(`<div class="mre-auto-roll"><button class="checkbox"></button><span class="label">${text}</span></div>`);
+    const element = $(`<label class="mre-auto-roll"><input type="checkbox" /><span class="label">${text}</span></label>`);
 
     const flag = item.getFlag(MODULE_NAME, `autoRoll${target}`);
-    const state = threeWay ? _stateFromNullableBoolean(flag) : _stateFromBoolean(flag);
+    const tooltip = threeWay ? _threeWayTooltip(flag) : _twoWayTooltip(flag);
+    element.prop("title", game.i18n.localize(tooltip));
 
-    const button = element.find("button")
-        .addClass(`${state.state}`)
-        .attr("data-auto-roll-target", target)
-        .attr("title", game.i18n.localize(state.tooltip));
-    if (threeWay) button.addClass("three-way");
+    const checkbox = element.find("input[type=checkbox]")[0];
+    checkbox.checked = flag;
+    checkbox.dataset.autoRollTarget = target;
+    checkbox.disabled = locked
+    if (threeWay) {
+        checkbox.indeterminate = flag === undefined;
+        checkbox.dataset.state = _threeWayState(flag);
+        checkbox.classList.add("three-way");
+    }
 
     return element;
 }
 
-function _stateFromBoolean(bool) {
-    return {
-        state: bool ? "checked" : "unchecked",
-        tooltip: bool ? `${MODULE_NAME}.AUTO-ROLL.True` : `${MODULE_NAME}.AUTO-ROLL.False`
-    }
+function _twoWayTooltip(bool) {
+    return bool ? `${MODULE_NAME}.AUTO-ROLL.True` : `${MODULE_NAME}.AUTO-ROLL.False`;
 }
 
-const _threeWayTooltipKeys = {
-    "unchecked": `${MODULE_NAME}.AUTO-ROLL.OverrideFalse`,
-    "indeterminate": `${MODULE_NAME}.AUTO-ROLL.Default`,
-    "checked": `${MODULE_NAME}.AUTO-ROLL.OverrideTrue`,
+function _threeWayTooltip(nullableBool) {
+    if (nullableBool === undefined) return `${MODULE_NAME}.AUTO-ROLL.Default`;
+    if (nullableBool) return `${MODULE_NAME}.AUTO-ROLL.OverrideTrue`;
+    else return `${MODULE_NAME}.AUTO-ROLL.OverrideFalse`;
 }
 
-function _stateFromNullableBoolean(bool) {
-    const state= bool === undefined ? "indeterminate" : ( bool ? "checked" : "unchecked" );
-    return { state, tooltip: _threeWayTooltipKeys[state], };
+function _threeWayState(nullableBool) {
+    if (nullableBool === undefined) return 0;
+    if (nullableBool) return 1;
+    else return 2;
 }
 
 function _handleTwoWayCheckboxButtonPress(event, item) {
     const el = event.currentTarget;
     const target = el.dataset.autoRollTarget;
-    const button = $(el);
 
-    if (button.hasClass("checked")) {
-        // Checkbox is currently checked, next state is unchecked
-        item.unsetFlag(MODULE_NAME, `autoRoll${target}`);
-    } else {
-        // Checkbox is currently unchecked, next state is checked
+    if (el.checked) {
+        // Checkbox changing from unchecked to checked
         item.setFlag(MODULE_NAME, `autoRoll${target}`, true);
+    } else {
+        // Checkbox changing from checked to unchecked
+        item.unsetFlag(MODULE_NAME, `autoRoll${target}`);
     }
+
+    return true;
 }
 
 function _handleThreeWayCheckboxButtonPress(event, item) {
+    event.preventDefault();
     const el = event.currentTarget;
     const target = el.dataset.autoRollTarget;
-    const button = $(el);
+    const prevState = isFinite(el.dataset.state) ? parseInt(el.dataset.state) : 1;
 
-    if (button.hasClass("checked")) {
-        // Checkbox is currently checked, next state is unchecked
-        item.setFlag(MODULE_NAME, `autoRoll${target}`, false);
-    } else if (button.hasClass("indeterminate")) {
-        // Checkbox is currently indeterminate, next state is checked
-        item.setFlag(MODULE_NAME, `autoRoll${target}`, true);
-    } else {
-        // Checkbox is currently unchecked, next state is indeterminate
-        item.unsetFlag(MODULE_NAME, `autoRoll${target}`);
+    switch (prevState) {
+        case 0: // checkbox changing from indeterminate to checked
+            item.setFlag(MODULE_NAME, `autoRoll${target}`, true);
+            break
+        case 1: // checkbox changing from checked to unchecked
+            item.setFlag(MODULE_NAME, `autoRoll${target}`, false);
+            break;
+        case 2: // checkbox changing from unchecked to indeterminate
+            item.unsetFlag(MODULE_NAME, `autoRoll${target}`);
+            break;
+
     }
+
+    el.dataset.state = (prevState + 1) % 3;
+
+    return false;
 }


### PR DESCRIPTION
* Use native checkbox with intermediate for auto roll checkboxes

- this is far more likely to be compatible with other sheet modules, and will not display weird behavior like submitting the page.

* Ensure auto roll checkbox tooltip displays correctly

* disable inputs when sheet is not editable

- this can happen if the item is in a locked compendium or if the
current user is not an owner (I think)

* Make auto roll checkboxes the same size as default item sheet checkboxes

* don't use a cursor that indicates interaction when the sheet is locked